### PR TITLE
Refactor UnmarshalQRWithOpts for Optional Signature Verification

### DIFF
--- a/AnonAadhaar/AnonAadhaarV1.go
+++ b/AnonAadhaar/AnonAadhaarV1.go
@@ -84,13 +84,9 @@ type anonAadhaarV1CircuitInputs struct {
 
 func (a *AnonAadhaarV1Inputs) W3CCredential() (*verifiable.W3CCredential, error) {
 	QR := &AnonAadhaarDataV2{}
-	err := QR.UnmarshalQR(a.QRData)
+	err := QR.UnmarshalQRWithOpts(a.QRData, WithPublicKey(a.PubKey))
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal QRData: %w", err)
-	}
-
-	if err = verifySignature(QR.rawdata, QR.signature, a.PubKey); err != nil {
-		return nil, fmt.Errorf("failed to verify signature: %w", err)
 	}
 
 	credentialSubject := map[string]interface{}{
@@ -147,13 +143,9 @@ func (a *AnonAadhaarV1Inputs) InputsMarshal() ([]byte, error) {
 	templateRoot := tmpl.Root()
 
 	ah := &AnonAadhaarDataV2{}
-	err = ah.UnmarshalQR(a.QRData)
+	err = ah.UnmarshalQRWithOpts(a.QRData, WithPublicKey(a.PubKey))
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal QRData: %w", err)
-	}
-	err = verifySignature(ah.rawdata, ah.signature, a.PubKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to verify signature: %w", err)
 	}
 
 	// List of values to hash

--- a/AnonAadhaar/AnonAadhaarV1_test.go
+++ b/AnonAadhaar/AnonAadhaarV1_test.go
@@ -206,7 +206,7 @@ Q5I3LVZhZ3abc1uhLKNYD5GcG9i6cMTCqwrPKwm8L66YHzwClabh6fJI9QBzCU/6
 	require.ErrorContains(t, err, "is before current time")
 }
 
-func TestAnonAadhaarInputsMarshalV1_WrongSignature(t *testing.T) {
+func TestAnonAadhaar_WrongSignature(t *testing.T) {
 	qrDataBI, ok := big.NewInt(0).SetString(testDataLatest, 10)
 	require.True(t, ok)
 	inputs := &AnonAadhaarV1Inputs{
@@ -221,5 +221,8 @@ func TestAnonAadhaarInputsMarshalV1_WrongSignature(t *testing.T) {
 	}
 
 	_, err := inputs.InputsMarshal()
+	require.ErrorIs(t, err, ErrInvalidSignature)
+
+	_, err = inputs.W3CCredential()
 	require.ErrorIs(t, err, ErrInvalidSignature)
 }

--- a/AnonAadhaar/qr.go
+++ b/AnonAadhaar/qr.go
@@ -190,7 +190,7 @@ func (a *AnonAadhaarDataV2) UnmarshalQRWithOpts(data *big.Int, opts ...Unmarshal
 	return nil
 }
 
-// deprecated: use UnmarshalQRWithOpts instead
+// Deprecated: use UnmarshalQRWithOpts instead.
 func (a *AnonAadhaarDataV2) UnmarshalQR(data *big.Int) error {
 	r, err := createDecompressor(data.Bytes())
 	if err != nil {

--- a/AnonAadhaar/qr.go
+++ b/AnonAadhaar/qr.go
@@ -155,18 +155,19 @@ func (a *AnonAadhaarDataV2) verify() error {
 
 // UnmarshalQROpts options.
 type UnmarshalQROpts struct {
-	pubkey string
+	Pubkey string
 }
 
 // UnmarshalQROpt is a function that modifies UnmarshalQROpts.
-type UnmarshalQROpt func(*UnmarshalQROpts)
+type UnmarshalQROpt func(*UnmarshalQROpts) error
 
 // WithPublicKey sets the public key for signature verification.
 // Without the optional public key, UnmarshalQRWithOpts
 // will only unmarshal the QR data without verifying the signature.
-func WithPublicKey(pubkey string) func(*UnmarshalQROpts) {
-	return func(opts *UnmarshalQROpts) {
-		opts.pubkey = pubkey
+func WithPublicKey(pubkey string) UnmarshalQROpt {
+	return func(opts *UnmarshalQROpts) error {
+		opts.Pubkey = pubkey
+		return nil
 	}
 }
 
@@ -174,15 +175,20 @@ func WithPublicKey(pubkey string) func(*UnmarshalQROpts) {
 func (a *AnonAadhaarDataV2) UnmarshalQRWithOpts(data *big.Int, opts ...UnmarshalQROpt) error {
 	var options UnmarshalQROpts
 	for _, opt := range opts {
-		opt(&options)
+		if opt == nil {
+			continue
+		}
+		if err := opt(&options); err != nil {
+			return fmt.Errorf("failed to apply option: %w", err)
+		}
 	}
 
 	if err := a.UnmarshalQR(data); err != nil {
 		return err
 	}
 
-	if options.pubkey != "" {
-		if err := verifySignature(a.rawdata, a.signature, options.pubkey); err != nil {
+	if options.Pubkey != "" {
+		if err := verifySignature(a.rawdata, a.signature, options.Pubkey); err != nil {
 			return fmt.Errorf("failed to verify signature: %w", err)
 		}
 	}

--- a/AnonAadhaar/qr.go
+++ b/AnonAadhaar/qr.go
@@ -153,6 +153,44 @@ func (a *AnonAadhaarDataV2) verify() error {
 	return nil
 }
 
+// UnmarshalQROpts options.
+type UnmarshalQROpts struct {
+	pubkey string
+}
+
+// UnmarshalQROpt is a function that modifies UnmarshalQROpts.
+type UnmarshalQROpt func(*UnmarshalQROpts)
+
+// WithPublicKey sets the public key for signature verification.
+// Without the optional public key, UnmarshalQRWithOpts
+// will only unmarshal the QR data without verifying the signature.
+func WithPublicKey(pubkey string) func(*UnmarshalQROpts) {
+	return func(opts *UnmarshalQROpts) {
+		opts.pubkey = pubkey
+	}
+}
+
+// UnmarshalQRWithOpts unmarshals the given QR.
+func (a *AnonAadhaarDataV2) UnmarshalQRWithOpts(data *big.Int, opts ...UnmarshalQROpt) error {
+	var options UnmarshalQROpts
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if err := a.UnmarshalQR(data); err != nil {
+		return err
+	}
+
+	if options.pubkey != "" {
+		if err := verifySignature(a.rawdata, a.signature, options.pubkey); err != nil {
+			return fmt.Errorf("failed to verify signature: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// deprecated: use UnmarshalQRWithOpts instead
 func (a *AnonAadhaarDataV2) UnmarshalQR(data *big.Int) error {
 	r, err := createDecompressor(data.Bytes())
 	if err != nil {

--- a/AnonAadhaar/qr_test.go
+++ b/AnonAadhaar/qr_test.go
@@ -41,7 +41,7 @@ func TestQRData(t *testing.T) {
 	qrDataBI, ok := big.NewInt(0).SetString(expected["testQRData"], 10)
 	require.True(t, ok)
 	actual := &AnonAadhaarDataV2{}
-	err = actual.UnmarshalQR(qrDataBI)
+	err = actual.UnmarshalQRWithOpts(qrDataBI)
 	require.NoError(t, err)
 
 	assert.Equal(t, expected["undefined"], actual.Version, "Version mismatch")
@@ -97,6 +97,7 @@ func TestQRCode_Error(t *testing.T) {
 		input            string // QR data as string
 		expectedErr      error
 		errorDescription string
+		opts             []UnmarshalQROpt
 	}{
 		{
 			name:             "InvalidCompressedData",
@@ -140,6 +141,13 @@ func TestQRCode_Error(t *testing.T) {
 			expectedErr:      ErrInvalidQRVersion,
 			errorDescription: "failed to verify Aadhaar QR: invalid gender: 'P'",
 		},
+		{
+			name:             "InvalidSignature",
+			input:            testDataLatest,
+			expectedErr:      ErrInvalidSignature,
+			errorDescription: "invalid signature: crypto/rsa: verification error",
+			opts:             []UnmarshalQROpt{WithPublicKey("-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAh1+zYnvbcEm0Yz73s5u42odpUJMr9wv5bVw7sOE5nFNbrB+U++5I0f8cL2HoHnJOkwvLZzrD0jG/vxAKi6vii/gjEzUEgrkdIHxMP3D6GJs0MSQHiEXvIGOwPIH3BLtBOc3m28NVNT6Q9iq0gUwuxnlhV38UdNhCllqNYhWmAMPJkImgaKrRZvY2pWNs6gd+PlAF/9SO69x3+1meA8kPk2ZvQanZlx9tfaExeOe9or3NQiKy2+UbtXrpcoAfYbbWi1OUzXi5bJdhbGp239c1fX6UKyUM5IUMY+m3I7wu2WQ7lmeO2n/vwzQz/PKHXPWYu3bydWMLdCi07vOQBqzCKwIDAQAB\n-----END PUBLIC KEY-----")},
+		},
 	}
 
 	for _, tt := range tests {
@@ -148,7 +156,7 @@ func TestQRCode_Error(t *testing.T) {
 			require.True(t, ok, "Failed to convert input to big.Int")
 
 			actual := &AnonAadhaarDataV2{}
-			err := actual.UnmarshalQR(qrDataBI)
+			err := actual.UnmarshalQRWithOpts(qrDataBI, tt.opts...)
 			require.ErrorIs(t, err, tt.expectedErr)
 			require.ErrorContains(t, err, tt.errorDescription)
 		})

--- a/AnonAadhaar/qr_test.go
+++ b/AnonAadhaar/qr_test.go
@@ -146,7 +146,11 @@ func TestQRCode_Error(t *testing.T) {
 			input:            testDataLatest,
 			expectedErr:      ErrInvalidSignature,
 			errorDescription: "invalid signature: crypto/rsa: verification error",
-			opts:             []UnmarshalQROpt{WithPublicKey("-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAh1+zYnvbcEm0Yz73s5u42odpUJMr9wv5bVw7sOE5nFNbrB+U++5I0f8cL2HoHnJOkwvLZzrD0jG/vxAKi6vii/gjEzUEgrkdIHxMP3D6GJs0MSQHiEXvIGOwPIH3BLtBOc3m28NVNT6Q9iq0gUwuxnlhV38UdNhCllqNYhWmAMPJkImgaKrRZvY2pWNs6gd+PlAF/9SO69x3+1meA8kPk2ZvQanZlx9tfaExeOe9or3NQiKy2+UbtXrpcoAfYbbWi1OUzXi5bJdhbGp239c1fX6UKyUM5IUMY+m3I7wu2WQ7lmeO2n/vwzQz/PKHXPWYu3bydWMLdCi07vOQBqzCKwIDAQAB\n-----END PUBLIC KEY-----")},
+			opts: []UnmarshalQROpt{
+				WithPublicKey(
+					"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAh1+zYnvbcEm0Yz73s5u42odpUJMr9wv5bVw7sOE5nFNbrB+U++5I0f8cL2HoHnJOkwvLZzrD0jG/vxAKi6vii/gjEzUEgrkdIHxMP3D6GJs0MSQHiEXvIGOwPIH3BLtBOc3m28NVNT6Q9iq0gUwuxnlhV38UdNhCllqNYhWmAMPJkImgaKrRZvY2pWNs6gd+PlAF/9SO69x3+1meA8kPk2ZvQanZlx9tfaExeOe9or3NQiKy2+UbtXrpcoAfYbbWi1OUzXi5bJdhbGp239c1fX6UKyUM5IUMY+m3I7wu2WQ7lmeO2n/vwzQz/PKHXPWYu3bydWMLdCi07vOQBqzCKwIDAQAB\n-----END PUBLIC KEY-----",
+				),
+			},
 		},
 	}
 


### PR DESCRIPTION
This pull request refactors how QR data is unmarshaled and signature verification is handled in the `AnonAadhaar` package. The main improvement is the introduction of an options-based approach for unmarshaling QR data, allowing for more flexible and explicit control over whether signature verification is performed. Tests have been updated to reflect these changes and to improve coverage for signature verification errors.

**Refactoring QR Data Unmarshaling and Signature Verification:**

* Added `UnmarshalQRWithOpts` to `AnonAadhaarDataV2`, which accepts options (such as a public key) to control signature verification, and deprecated the old `UnmarshalQR` method in favor of this more flexible approach. Also introduced the `WithPublicKey` option and related types. (`AnonAadhaar/qr.go`)
* Updated usages in `AnonAadhaarV1.go` to use `UnmarshalQRWithOpts` with the `WithPublicKey` option instead of manually calling signature verification after unmarshaling. This simplifies the logic and centralizes signature verification. (`AnonAadhaar/AnonAadhaarV1.go`) [[1]](diffhunk://#diff-2c6838074ccbf8b7c5d70f2b0e5c79f095a8f3c0007acdd5ce994776bb49f9cfL87-L95) [[2]](diffhunk://#diff-2c6838074ccbf8b7c5d70f2b0e5c79f095a8f3c0007acdd5ce994776bb49f9cfL150-L157)

**Test Improvements:**

* Updated tests to use the new `UnmarshalQRWithOpts` method and to explicitly test signature verification failures, including new test cases for invalid signatures. (`AnonAadhaar/qr_test.go`) [[1]](diffhunk://#diff-3d98e52b8623aac409aa46d61516ecb88debc75be79c62f5824728c71e22bec4L44-R44) [[2]](diffhunk://#diff-3d98e52b8623aac409aa46d61516ecb88debc75be79c62f5824728c71e22bec4R100) [[3]](diffhunk://#diff-3d98e52b8623aac409aa46d61516ecb88debc75be79c62f5824728c71e22bec4R144-R154) [[4]](diffhunk://#diff-3d98e52b8623aac409aa46d61516ecb88debc75be79c62f5824728c71e22bec4L151-R163)
* Improved the test for invalid signatures to check both `InputsMarshal` and `W3CCredential` methods for proper error handling. (`AnonAadhaar/AnonAadhaarV1_test.go`) [[1]](diffhunk://#diff-dab5d5707bcf79dea414c4203c5cfdf48e9f0e3879e5286e2a9d1b3c892abfa5L209-R209) [[2]](diffhunk://#diff-dab5d5707bcf79dea414c4203c5cfdf48e9f0e3879e5286e2a9d1b3c892abfa5R225-R227)